### PR TITLE
:+1: Make `option` behave as `alt` on macOS

### DIFF
--- a/.config/alacritty/alacritty.toml
+++ b/.config/alacritty/alacritty.toml
@@ -15,6 +15,7 @@ program = "/bin/zsh"
 
 [window]
 startup_mode = "Maximized"
+option_as_alt = "Both"
 
 [window.padding]
 x = 5


### PR DESCRIPTION
tmux で session を切り替える際に `M-a` などの `meta` の入力が必要なケースで切り替えできない問題があった。
https://alacritty.org/config-alacritty.html#s20
