### PR TITLE
Add difit, gitmoji-cli and harden mise config

### DIFF
--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -3,6 +3,7 @@ bun = "latest"
 node = "lts"
 "npm:ccstatusline" = "2"
 "npm:difit" = "4"
+"npm:gitmoji-cli" = "9"
 
 [settings]
 minimum_release_age = "7d"

--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -1,3 +1,7 @@
 [tools]
 bun = "latest"
 "npm:ccstatusline" = "latest"
+
+[settings]
+minimum_release_age = "7d"
+paranoid = true

--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -1,7 +1,7 @@
 [tools]
 bun = "latest"
 node = "lts"
-"npm:ccstatusline" = "latest"
+"npm:ccstatusline" = "2"
 "npm:difit" = "4"
 
 [settings]

--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -1,6 +1,8 @@
 [tools]
 bun = "latest"
+node = "lts"
 "npm:ccstatusline" = "latest"
+"npm:difit" = "4"
 
 [settings]
 minimum_release_age = "7d"


### PR DESCRIPTION
[generated by claude code]

neovim 移行（feature/20260507_02）とは独立して、mise の tools 追加とセキュリティ設定を先行して取り込みます。

## 変更内容
- mise settings 追加: `minimum_release_age = "7d"`（fuzzy 指定で 7 日以内の版を回避）、`paranoid = true`（config trust 厳格化・HTTPS 強制・community plugin 制限）
- difit (major 4) を追加。npm ランタイムとして `node = "lts"` も追加
- ccstatusline を latest から major 2 に固定（minimum_release_age を効かせるため）
- gitmoji-cli (major 9) を追加

## 補足
- npm ツールは major 固定とし、実バージョンは minimum_release_age で制御。lockfile は今回見送り（npm backend が provenance/checksum を lockfile に記録せず、`bun=latest` / `node=lts` の追従を保つため）。