### PR TITLE
Add plan/org statusline and cost/token widgets to ccstatusline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,7 @@ deploy: clean
 	ln -s $(ROOT)/dot_claude/settings.json $$HOME/.claude/settings.json
 	ln -s $(ROOT)/dot_claude/hooks $$HOME/.claude/hooks
 	ln -s $(ROOT)/dot_claude/CLAUDE.md $$HOME/.claude/CLAUDE.md
+	ln -s $(ROOT)/dot_claude/scripts $$HOME/.claude/scripts
 
 # clean dotfiles already deployed.
 clean:
@@ -151,6 +152,7 @@ clean:
 	rm -f $$HOME/.claude/settings.json &> /dev/null || true
 	rm -rf $$HOME/.claude/hooks &> /dev/null || true
 	rm -f $$HOME/.claude/CLAUDE.md &> /dev/null || true
+	rm -rf $$HOME/.claude/scripts &> /dev/null || true
 
 build_brew:
 	# setup Homebrew.

--- a/dot_claude/scripts/display-plan-and-org-for-statusline.sh
+++ b/dot_claude/scripts/display-plan-and-org-for-statusline.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Show Claude subscription tier (and org, if any) for ccstatusline.
+# `claude auth status` is slow, so cache it and refresh in the background when stale.
+
+CONFIG_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+CACHE="$CONFIG_DIR/.plan_org_cache"
+TTL_MIN=60
+
+refresh() {
+  local auth tsv
+  auth=$(claude auth status 2>/dev/null) || return
+  tsv=$(jq -r '[.subscriptionType // "", .orgName // ""] | @tsv' <<<"$auth" 2>/dev/null) || return
+  [ -n "$tsv" ] && printf '%s\n' "$tsv" >"$CACHE"
+}
+
+if [ ! -f "$CACHE" ]; then
+  refresh &
+  echo "[Loading...]"
+  exit 0
+fi
+
+# Stale: refresh in the background while still showing the cached value.
+[ -n "$(find "$CACHE" -mmin +"$TTL_MIN" 2>/dev/null)" ] && refresh &
+
+IFS=$'\t' read -r tier org <"$CACHE"
+[ -n "$org" ] && echo "[${tier}][${org}]" || echo "[${tier}]"

--- a/dot_config/ccstatusline/settings.json
+++ b/dot_config/ccstatusline/settings.json
@@ -67,6 +67,30 @@
         "type": "claude-session-id",
         "color": "brightBlack"
       }
+    ],
+    [
+      {
+        "id": "9b62f7fa-34be-47b7-b11d-1715f95ea61b",
+        "type": "session-cost",
+        "color": "brightBlack"
+      },
+      {
+        "id": "dbcbedcd-955e-47f7-8abb-aed9c29e78cc",
+        "type": "separator"
+      },
+      {
+        "id": "5fb7ed7a-58bf-4a09-b363-aedafae0b5cf",
+        "type": "tokens-total",
+        "color": "brightBlack"
+      }
+    ],
+    [
+      {
+        "id": "91efa3f9-56c1-44b3-95a6-5711e327466b",
+        "type": "custom-command",
+        "color": "brightBlue",
+        "commandPath": "~/.claude/scripts/display-plan-and-org-for-statusline.sh"
+      }
     ]
   ],
   "flexMode": "full-minus-40",
@@ -74,6 +98,7 @@
   "colorLevel": 2,
   "inheritSeparatorColors": false,
   "globalBold": false,
+  "gitCacheTtlSeconds": 5,
   "minimalistMode": false,
   "powerline": {
     "enabled": false,


### PR DESCRIPTION
[generated by claude code]

ccstatusline に表示項目を追加し、Claude のプラン/組織を表示する custom-command スクリプトを導入します。

## 変更内容
- `dot_claude/scripts/display-plan-and-org-for-statusline.sh` を追加
  - `claude auth status` から subscriptionType / orgName を取得し `[tier][org]` 形式で表示
  - `claude auth status` が遅いため結果をキャッシュし、60 分を超えたらバックグラウンドで更新（stale-while-revalidate）
  - Makefile で `dot_claude/scripts` を `~/.claude/scripts` に symlink（install/clean）
- ccstatusline `settings.json`
  - session-cost + tokens-total の行を追加
  - 上記スクリプトを custom-command 行として配置
  - `gitCacheTtlSeconds = 5` を設定
