### PR TITLE
:art: Rebind lazygit to prefix+ctrl+g and restore goto to default

### DIFF
--- a/dot_config/herdr/config.toml
+++ b/dot_config/herdr/config.toml
@@ -7,7 +7,6 @@ onboarding = false
 prefix = "ctrl+t"
 
 # Unset built-in actions so the custom commands below can claim these chords.
-goto = ""
 new_workspace = ""
 
 # `%` splits right (column), `"` splits down (row).
@@ -34,7 +33,7 @@ description = "new workspace at current pane cwd"
 
 # Open lazygit in a temporary pane.
 [[keys.command]]
-key = "prefix+g"
+key = "prefix+ctrl+g"
 type = "pane"
 command = "lazygit"
 description = "run lazygit"


### PR DESCRIPTION
## Summary

- default の `goto` action (workspace ジャンプ) が prefix+g にあり有用そうなので、既定を復活させる
- lazygit は prefix+ctrl+g へ退避。既存 `prefix+ctrl+f` (file picker) と揃えた `prefix+ctrl+<letter>` パターンで指癖にも一貫性が出る

## Test plan

- [x] `herdr server reload-config` 後、`prefix+g` で workspace goto UI が開く
- [x] `prefix+ctrl+g` で lazygit の一時 pane が起動する

🤖 Generated with [Claude Code](https://claude.com/claude-code)